### PR TITLE
email.txt template missing from installation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include LICENSE
 include README.rst
-recursive-include djangocms_forms *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
+recursive-include djangocms_forms *.html *.txt *.png *.gif *js *.css *jpg *jpeg *svg *py


### PR DESCRIPTION
email.html is provided as a template, but email.txt wasn't. I hope this quick fix solves that. Thank you, so far, this plugin is working marvellously.