### PR TITLE
fix customization of css classes in javascript

### DIFF
--- a/djangocms_forms/static/js/djangocms_forms/djangocms_forms.js
+++ b/djangocms_forms/static/js/djangocms_forms/djangocms_forms.js
@@ -13,8 +13,8 @@
             server_error: 'We\'re sorry. Something Unexpected Happened. Please Try Again Later.'
         };
 
-        this.each(function(options) {
-            var options = $.extend( {}, defaults, options) ;
+        this.each(function() {
+            options = $.extend( {}, defaults, options) ;
 
             var el = $(this),
                 form_wrapper = $(options.form_wrapper, el),


### PR DESCRIPTION
* `each` method callback accepts index as first argument and no understandable reasons to extend `defaults` object with `index`;
* Remove `var` before `options` for creating closure with plugin options