### PR TITLE
Change form submit event handler

### DIFF
--- a/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
+++ b/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
@@ -37,9 +37,9 @@
                 success: $.proxy(this.ajaxSuccess, this),
                 error: $.proxy(this.ajaxError, this)
             };
-            this.form.on('submit', function() {
+            this.form.on('submit', function(e) {
                 $(this).ajaxSubmit(ajaxOptions);
-                return false;
+                e.preventDefault();
             });
 
             if (typeof(grecaptcha) == 'undefined') {


### PR DESCRIPTION
When submitting a form, instead of `return false;` it's better to use `event.prevetDefault();`. I've came to this problem when trying to setup GoogleTagManager to track ajax based form submits.

For more details, see http://ka.lpe.sh/2013/06/01/return-false-vs-preventdefault-javascript/