### PR TITLE
Refactor Redirect Delay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,14 @@ By default, ``djangocms-forms`` adds additional css classes to all form inputs. 
 
 e.g. the above setting would generate ``<input class"form-control" ....`` for all fields.
 
+By default, djangocms-forms will redirect a successful form submission after 1000 milliseconds (1 second). You may provide your own redirect delay value for all forms site-wide via settings:
+
+    DJANGOCMS_FORMS_REDIRECT_DELAY = 10000  # 10 seconds
+
+or on a per-form basis via the ``redirect_delay`` field. The order of precedence for the redirect value is always:
+
+    instance.redirect_delay > DJANGOCMS_FORMS_REDIRECT_DELAY > 1000 (default)
+
 
 Preview
 --------

--- a/djangocms_forms/__init__.py
+++ b/djangocms_forms/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.15'
+__version__ = '0.1.16'
 
 default_app_config = 'djangocms_forms.apps.DjangoCMSFormsConfig'

--- a/djangocms_forms/cms_plugins.py
+++ b/djangocms_forms/cms_plugins.py
@@ -79,7 +79,7 @@ class FormPlugin(CMSPluginBase):
                 'fields': ('post_submit_msg', )
             }),
             (None, {
-                'fields': ('success_redirect', ('page_redirect', 'external_redirect'), ),
+                'fields': ('success_redirect', ('page_redirect', 'external_redirect'), 'redirect_delay',),
             }),
             (None, {
                 'description': '<strong>Submission Settings</strong> &mdash; '
@@ -108,9 +108,13 @@ class FormPlugin(CMSPluginBase):
             initial={'referrer': request.path_info}, form_definition=instance,
             label_suffix='', auto_id='%s')
 
+        redirect_delay = instance.redirect_delay or \
+            getattr(settings, 'DJANGOCMS_FORMS_REDIRECT_DELAY', 1000)
+
         context.update({
             'form': form,
             'recaptcha_site_key': settings.DJANGOCMS_FORMS_RECAPTCHA_PUBLIC_KEY,
+            'redirect_delay': redirect_delay
         })
         return context
 

--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -53,6 +53,18 @@ class FormDefinitionAdminForm(forms.ModelForm):
             for field in storage_fields:
                 self._errors[field] = self.error_class([error_msg])
 
+        # if a rediret_delay is specified, ensure there is either a page_redirect
+        # or external_redirect present
+        page_redirect = cleaned_data.get('page_redirect')
+        external_redirect = cleaned_data.get('external_redirect')
+        redirect_delay = cleaned_data.get('redirect_delay')
+
+        if redirect_delay and not any([page_redirect, external_redirect]):
+            self._errors['redirect_delay'] = self.error_class([
+                _('You must specify either a page or external redirect when '
+                'adding a redirect delay.')
+            ])
+
         return cleaned_data
 
     def clean_form_template(self):

--- a/djangocms_forms/migrations/0004_redirect_delay.py
+++ b/djangocms_forms/migrations/0004_redirect_delay.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_forms', '0003_add_referrer_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='formdefinition',
+            name='redirect_delay',
+            field=models.PositiveIntegerField(verbose_name='Redirect Delay', blank=True, null=True, help_text="Wait this number of milliseconds before redirecting."),
+        ),
+    ]

--- a/djangocms_forms/models.py
+++ b/djangocms_forms/models.py
@@ -54,6 +54,11 @@ class FormDefinition(CMSPlugin):
     external_redirect = models.URLField(
         _('External URL'), blank=True,
         help_text=_('e.g. http://example.com/thank-you'))
+    redirect_delay = models.PositiveIntegerField(
+        _('Redirect Delay'), blank=True, null=True,
+        help_text=_('Wait this number of milliseconds before redirecting. '
+            '1000 milliseconds = 1 second.')
+    )
 
     # Email
     email_to = models.CharField(

--- a/djangocms_forms/south_migrations/0003_auto_add_redirect_delay.py
+++ b/djangocms_forms/south_migrations/0003_auto_add_redirect_delay.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'FormDefinition.redirect_delay'
+        db.add_column(u'djangocms_forms_formdefinition', 'redirect_delay',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(blank=True, null=True))
+
+
+    def backwards(self, orm):
+        # Deleting field 'FormDefinition.redirect_delay'
+        db.delete_column(u'djangocms_forms_formdefinition', 'redirect_delay')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.page': {
+            'Meta': {'ordering': "('tree_id', 'lft')", 'unique_together': "(('publisher_is_draft', 'application_namespace'), ('reverse_id', 'site', 'publisher_is_draft'))", 'object_name': 'Page'},
+            'application_namespace': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'application_urls': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'changed_by': ('django.db.models.fields.CharField', [], {'max_length': '70'}),
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '70'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_navigation': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'is_home': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'languages': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'limit_visibility_in_menu': ('django.db.models.fields.SmallIntegerField', [], {'default': 'None', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'login_required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'navigation_extenders': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['cms.Page']"}),
+            'placeholders': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['cms.Placeholder']", 'symmetrical': 'False'}),
+            'publication_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'publication_end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'publisher_is_draft': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'publisher_public': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'publisher_draft'", 'unique': 'True', 'null': 'True', 'to': "orm['cms.Page']"}),
+            'reverse_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'revision_id': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'djangocms_pages'", 'to': u"orm['sites.Site']"}),
+            'soft_root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'template': ('django.db.models.fields.CharField', [], {'default': "'INHERIT'", 'max_length': '100'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'xframe_options': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djangocms_forms.form': {
+            'Meta': {'object_name': 'Form'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'djangocms_forms.formdefinition': {
+            'Meta': {'object_name': 'FormDefinition', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'email_from': ('django.db.models.fields.EmailField', [], {'max_length': '255', 'blank': 'True'}),
+            'email_subject': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email_to': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email_uploaded_files': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'external_redirect': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'form_template': ('django.db.models.fields.CharField', [], {'default': "'djangocms_forms/form_template/default.html'", 'max_length': '150', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'page_redirect': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'plugin_reference': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'plugin'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['djangocms_forms.Form']"}),
+            'post_submit_msg': ('django.db.models.fields.TextField', [], {'default': "u'Thank You'", 'blank': 'True'}),
+            'save_data': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'spam_protection': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'submit_btn_txt': ('django.db.models.fields.CharField', [], {'default': "u'Submit'", 'max_length': '100'}),
+            'success_redirect': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'redirect_delay': ('django.db.models.fields.PositiveIntegerField', [], {'blank': 'True', 'null': 'True'}),
+        },
+        u'djangocms_forms.formfield': {
+            'Meta': {'ordering': "('position',)", 'object_name': 'FormField'},
+            'choice_values': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'field_type': ('django.db.models.fields.CharField', [], {'default': "'text'", 'max_length': '100'}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fields'", 'to': u"orm['djangocms_forms.FormDefinition']"}),
+            'help_text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'placeholder_text': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'djangocms_forms.formsubmission': {
+            'Meta': {'ordering': "('-creation_date',)", 'object_name': 'FormSubmission'},
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'form_data': ('jsonfield.fields.JSONField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'plugin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submissions'", 'to': u"orm['djangocms_forms.Form']"}),
+            'referrer': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'})
+        },
+        u'sites.site': {
+            'Meta': {'ordering': "(u'domain',)", 'object_name': 'Site', 'db_table': "u'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['djangocms_forms']

--- a/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
+++ b/djangocms_forms/static/js/djangocms_forms/jquery.djangocms-forms.js
@@ -17,7 +17,11 @@
 
             reCaptchaSiteKey: '',
             reCaptchaTheme: 'light',
-            reCaptchaSize: 'normal'
+            reCaptchaSize: 'normal',
+
+            // needed in case someone overrides the template and doesn't pass
+            // in the value when initializing the cmsForms object
+            redirectDelay: 1000
         };
 
     function CMSForms(el, options) {
@@ -90,7 +94,7 @@
             if (response.redirectUrl) {
                 setTimeout(function() {
                     window.location = response.redirectUrl;
-                }, 1000);
+                }, this.settings.redirectDelay);
             }
         },
         formInvalid: function(response) {

--- a/djangocms_forms/templates/djangocms_forms/form_template/default.html
+++ b/djangocms_forms/templates/djangocms_forms/form_template/default.html
@@ -63,8 +63,10 @@
 
 	<script type="application/javascript">
 		$(function() {
-		  $('.forms').cmsForms({'reCaptchaSiteKey': '{{ recaptcha_site_key }}'});
+		  $('.forms').cmsForms({
+			  'reCaptchaSiteKey': '{{ recaptcha_site_key }}',
+			  'redirect_delay': {{ redirect_delay|default:1000 }}
+		  });
 		});
 	</script>
 {% endaddtoblock %}
-

--- a/djangocms_forms/templates/djangocms_forms/form_template/default.html
+++ b/djangocms_forms/templates/djangocms_forms/form_template/default.html
@@ -65,7 +65,7 @@
 		$(function() {
 		  $('.forms').cmsForms({
 			  'reCaptchaSiteKey': '{{ recaptcha_site_key }}',
-			  'redirect_delay': {{ redirect_delay|default:1000 }}
+			  'redirectDelay': {{ redirect_delay|default:1000 }}
 		  });
 		});
 	</script>


### PR DESCRIPTION
## Rationale
djangocms-forms uses a hard-coded redirect delay value of 1000, which may not suit all use cases.

This pull request makes the redirect delay value configurable on a per-form basis via the FormDefinition model, site-wide via settings or falling back to the original value of 1000 milliseconds.

## Work
- Added `redirect_delay` field to FormDefinition model.
- Added migrations for `redirect_delay` field for Django 1.8+ and South.
- Updated cms plugin to include `redirect_delay` in fieldsets and pass `redirect_delay` value to template.
- Updated `FormDefinitionAdminForm` to ensure a redirect is provided if a `redirect_delay` is specified.
- Updated default form template to pass `redirect_delay` to the `cmsForms` object constructor.
- Updated cmsForms JavaScript to pass in `redirect_delay` value and use the setting value instead of a hard-coded value of 1000 milliseconds.
- Version bump to 0.1.16.
- Updated documentation on use of `redirect_delay` field.

## Results
![test form - google chrome_014](https://cloud.githubusercontent.com/assets/86738/12488379/4f97d6fc-c039-11e5-8e41-20302f811d57.jpg)


## Testing

#### per-form redirect delay
- Create a form, and enter either a page or external site to redirect to as well as a `redirect_delay` value.
- Publish your changes.
- Visit the page with your form and submit it.
- Verify that the correct number of milliseconds has passed before the redirect occurs.

#### site-wide redirect delay
- Add a `DJANGOCMS_FORMS_REDIRECT_DELAY` to your settings.
- Using Google Chrome Developer tools or other DOM inspector, verify that the number of milliseconds is displayed for the `redirect_delay` (see screenshot above for example)
- Create a form. Do not enter a `redirect_delay` value. Publish.
- Visit the page with your form and submit it.
- Verify that the correct number of milliseconds has passed before the redirect occurs.

#### default value
- Remove the `DJANGOCMS_FORMS_REDIRECT_DELAY` from your settings.
- Create a form. Do not enter a `redirect_delay` value. Publish.
- Visit the page with your form and submit it.
- Verify that the correct number of milliseconds has passed before the redirect occurs.