### PR TITLE
To remove depreciated url patterns for Django 1.10

### DIFF
--- a/djangocms_forms/admin.py
+++ b/djangocms_forms/admin.py
@@ -98,7 +98,7 @@ class FormSubmissionAdmin(admin.ModelAdmin):
         Add the export view to urls.
         """
         urls = super(FormSubmissionAdmin, self).get_urls()
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
 
         def wrap(view):
             def wrapper(*args, **kwargs):
@@ -107,10 +107,9 @@ class FormSubmissionAdmin(admin.ModelAdmin):
 
         info = self.model._meta.app_label, self.model._meta.model_name
 
-        extra_urls = patterns(
-            '',
+        extra_urls = [
             url(r'^export/$', wrap(self.export_view), name='%s_%s_export' % info),
-        )
+        ]
         return extra_urls + urls
 
     @csrf_protect_m

--- a/djangocms_forms/urls.py
+++ b/djangocms_forms/urls.py
@@ -2,11 +2,10 @@
 
 from __future__ import unicode_literals
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import FormSubmission
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^forms/submit/$', FormSubmission.as_view(), name='djangocms_forms_submissions'),
-)
+]


### PR DESCRIPTION
Django 1.10 is removing the depreciated urls patterns, so this update removes patterns where appropriate.