### PR TITLE
Removed re-opening uploaded files before attaching to email message

### DIFF
--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -375,7 +375,10 @@ class FormBuilder(forms.Form):
 
         if self.form_definition.email_uploaded_files:
             for field, filedata in self.files.items():
-                email.attach(filedata.name, filedata.read(), filedata.content_type)
+                filedata.open('rb')
+                content = filedata.read()
+                filedata.close()
+                email.attach(filedata.name, content, filedata.content_type)
 
         email.send(fail_silently=False)
 

--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -375,10 +375,7 @@ class FormBuilder(forms.Form):
 
         if self.form_definition.email_uploaded_files:
             for field, filedata in self.files.items():
-                filedata.open('r')
-                content = filedata.read()
-                filedata.close()
-                email.attach(filedata.name, content, filedata.content_type)
+                email.attach(filedata.name, filedata.read(), filedata.content_type)
 
         email.send(fail_silently=False)
 


### PR DESCRIPTION
had the following error when testing a form on AWS. 

> File "/opt/python/run/venv/lib/python3.4/site-packages/django/core/mail/message.py", line 171, in __init__
>     MIMEText.__init__(self, _text, _subtype, None)
>   File "/usr/lib64/python3.4/email/mime/text.py", line 33, in __init__
>     _text.encode('us-ascii')
> AttributeError: 'bytes' object has no attribute 'encode'

Looking at the email attachment code and comparing it to some of my own, it looks like the issue _may_ stem from re-opening an uploaded file in the default text mode, instead of binary.

Not doing this and reading the contents of the file object directly fix the issue for me.

This was happening with 0.2.1 & 0.2.2
