### PR TITLE
Validate if referrer was manupulated

### DIFF
--- a/djangocms_forms/views.py
+++ b/djangocms_forms/views.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect
+from django.http import Http404
+from django.utils.http import is_safe_url
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView
@@ -49,7 +51,18 @@ class FormSubmission(FormView):
             return JsonResponse(response)
         else:
             messages.success(self.request, strip_tags(form.form_definition.post_submit_msg))
-            return redirect(form.redirect_url or form.cleaned_data['referrer'])
+            if form.redirect_url:
+                return redirect(form.redirect_url)
+
+            redirect_url = form.cleaned_data['referrer']
+            if is_safe_url(redirect_url, self.request.get_host()):
+                return redirect(redirect_url)
+
+            # If for some reason someone was manipulated referrer parameter to
+            # point to unsafe URL then we will redirect to home page
+            # It is not good to raise an error because form was already saved
+            # and mail notification was sent
+            return redirect('/')
 
     def form_invalid(self, form, *args, **kwargs):
         if self.request.is_ajax():
@@ -59,5 +72,11 @@ class FormSubmission(FormView):
             }
             return JsonResponse(response)
         else:
-            messages.error(self.request, _(u'Invalid form data, one or more fields had errors'))
-            return redirect(form.cleaned_data['referrer'])
+            redirect_url = form.cleaned_data.get('referrer') or self.request.META.get('HTTP_REFERER', '')
+            if is_safe_url(redirect_url, self.request.get_host()):
+                messages.error(self.request, _(u'Invalid form data, one or more fields had errors'))
+                return redirect(redirect_url)
+
+            # If for some reason someone was manipulated referrer parameter to
+            # point to unsafe URL then we will raise Http404 as we do with invalid form_id
+            raise Http404(_('Invalid referrer'))


### PR DESCRIPTION
Prevent Error 500 if referrer field is missing in the form and also prevent redirection to malicious URLs

Fixed #39