### PR TITLE
Prevent user from entering HTML through the forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+env
+.env
+venv
+.venv
 
 # Installer logs
 pip-log.txt

--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -13,6 +13,7 @@ from django.template.defaultfilters import slugify
 from django.template.loader import get_template, render_to_string
 from django.utils.translation import ugettext_lazy as _
 
+from django_bleach.forms import BleachField
 from ipware.ip import get_ip
 from unidecode import unidecode
 
@@ -154,7 +155,7 @@ class FormBuilder(forms.Form):
         field_attrs.update({
             'widget': forms.TextInput(attrs=widget_attrs)
         })
-        return forms.CharField(**field_attrs)
+        return BleachField(**field_attrs)
 
     def prepare_textarea(self, field):
         field_attrs = field.build_field_attrs()
@@ -163,7 +164,7 @@ class FormBuilder(forms.Form):
         field_attrs.update({
             'widget': forms.Textarea(attrs=widget_attrs)
         })
-        return forms.CharField(**field_attrs)
+        return BleachField(**field_attrs)
 
     def prepare_email(self, field):
         field_attrs = field.build_field_attrs()
@@ -271,7 +272,7 @@ class FormBuilder(forms.Form):
         field_attrs.update({
             'widget': forms.HiddenInput(attrs=widget_attrs),
         })
-        return forms.CharField(**field_attrs)
+        return BleachField(**field_attrs)
 
     def prepare_number(self, field):
         field_attrs = field.build_field_attrs()
@@ -298,7 +299,7 @@ class FormBuilder(forms.Form):
         field_attrs.update({
             'widget': forms.PasswordInput(attrs=widget_attrs),
         })
-        return forms.CharField(**field_attrs)
+        return BleachField(**field_attrs)
 
     def prepare_phone(self, field):
         field_attrs = field.build_field_attrs()
@@ -307,7 +308,7 @@ class FormBuilder(forms.Form):
         field_attrs.update({
             'widget': TelephoneInput(attrs=widget_attrs),
         })
-        return forms.CharField(**field_attrs)
+        return BleachField(**field_attrs)
 
     def save(self, request):
         form_data = []

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'django-appconf',
+        'django-bleach>=0.4.0',
         'django-ipware',
         'jsonfield',
         'unidecode',


### PR DESCRIPTION
The use of `CharField` in forms is vulnerable to stored cross site scripting attacks.

User supplied data through the forms needs to be sanitised to prevent malicious use. Currently a user could enter into the various `CharFields` something like `<script>alert("Hi")</script>` and when an administrator opens that form submission in the admin, the script would be executed & the alert would appear.

This change introduces a dependency on `django-bleach` but it then uses it to sanitise HTML entered by the user.