### PR TITLE
for usage with djangocms-3.6.0

### DIFF
--- a/djangocms_forms/fields.py
+++ b/djangocms_forms/fields.py
@@ -64,7 +64,7 @@ class PluginReferenceField(models.ForeignKey):
         super(PluginReferenceField, self).__init__(*args, **kwargs)
 
     def _create(self, model_instance):
-        return self.rel.to._default_manager.create(name=model_instance.name)
+        return self.remote_field.model._default_manager.create(name=model_instance.name)
 
     def pre_save(self, model_instance, add):
         if not model_instance.pk and add:

--- a/djangocms_forms/forms.py
+++ b/djangocms_forms/forms.py
@@ -7,7 +7,7 @@ import re
 from django import forms
 from django.contrib.admin.widgets import AdminDateWidget, FilteredSelectMultiple
 from django.core.mail import EmailMultiAlternatives
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import TemplateDoesNotExist
 from django.template.defaultfilters import slugify
 from django.template.loader import get_template, render_to_string

--- a/djangocms_forms/migrations/0001_initial.py
+++ b/djangocms_forms/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='FormDefinition',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete='CASCADE')),
                 ('name', models.CharField(max_length=255, verbose_name='Form Name')),
                 ('title', models.CharField(max_length=150, verbose_name='Title', blank=True)),
                 ('description', models.TextField(verbose_name='Description', blank=True)),
@@ -68,7 +68,7 @@ class Migration(migrations.Migration):
                 ('initial', models.CharField(max_length=255, verbose_name='Default Value', blank=True)),
                 ('choice_values', models.TextField(help_text='Enter options one per line. For "File Upload" field type, enter allowed filetype (e.g .pdf) one per line.', verbose_name='Choices', blank=True)),
                 ('position', models.PositiveIntegerField(null=True, verbose_name='Position', blank=True)),
-                ('form', models.ForeignKey(related_name='fields', to='djangocms_forms.FormDefinition')),
+                ('form', models.ForeignKey(related_name='fields', to='djangocms_forms.FormDefinition', on_delete='CASCADE')),
             ],
             options={
                 'ordering': ('position',),
@@ -84,8 +84,8 @@ class Migration(migrations.Migration):
                 ('creation_date', models.DateTimeField(auto_now=True, verbose_name='Date')),
                 ('ip', models.GenericIPAddressField(null=True, verbose_name=b'IP', blank=True)),
                 ('form_data', jsonfield.fields.JSONField(verbose_name='Form Data')),
-                ('created_by', models.ForeignKey(editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='User')),
-                ('plugin', models.ForeignKey(related_name='submissions', editable=False, to='djangocms_forms.Form', verbose_name='Form')),
+                ('created_by', models.ForeignKey(editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='User', on_delete='CASCADE')),
+                ('plugin', models.ForeignKey(related_name='submissions', editable=False, to='djangocms_forms.Form', verbose_name='Form', on_delete='CASCADE')),
             ],
             options={
                 'ordering': ('-creation_date',),

--- a/djangocms_forms/models.py
+++ b/djangocms_forms/models.py
@@ -128,7 +128,7 @@ class FormDefinition(CMSPlugin):
 
 @python_2_unicode_compatible
 class FormField(models.Model):
-    form = models.ForeignKey(FormDefinition, related_name='fields')
+    form = models.ForeignKey(FormDefinition, related_name='fields', on_delete='CASCADE')
     field_type = models.CharField(
         _('Field Type'), max_length=100,
         choices=settings.DJANGOCMS_FORMS_FIELD_TYPES,
@@ -223,7 +223,7 @@ class FormField(models.Model):
 @python_2_unicode_compatible
 class FormSubmission(models.Model):
     plugin = models.ForeignKey(
-        Form, verbose_name=_('Form'), editable=False, related_name='submissions')
+        Form, verbose_name=_('Form'), editable=False, related_name='submissions', on_delete='CASCADE')
     creation_date = models.DateTimeField(_('Date'), auto_now=True)
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL, verbose_name=_('User'), editable=False, null=True)


### PR DESCRIPTION
Installed it for djangocms-3.6.0 in my infrastructure and fixed errors. The description concerning including urls might also get updated to use "path" instead of "url".